### PR TITLE
New test case for display names.

### DIFF
--- a/src/PowerFx.Dataverse.Tests/DataverseTests.cs
+++ b/src/PowerFx.Dataverse.Tests/DataverseTests.cs
@@ -1486,6 +1486,28 @@ END
             Assert.AreEqual(expr, result.LogicalFormula);
         }
 
+        // Translate an expr with both display and logical names
+        [DataTestMethod]
+        [DataRow("new_price * Quantity", "Price * Quantity", "new_price * new_quantity")]
+        public void MixedTranslate(string mixedExpr, string expectedDisplay, string expectedLogical)
+        {
+            var provider = new MockXrmMetadataProvider(RelationshipModels);
+            var engine = new PowerFx2SqlEngine(RelationshipModels[0].ToXrm(), new CdsEntityMetadataProvider(provider));
+            
+            var actualTranslation = engine.ConvertToDisplay(mixedExpr);
+            Assert.AreEqual(expectedDisplay, actualTranslation);
+
+            actualTranslation = engine.ConvertToDisplay(expectedLogical);
+            Assert.AreEqual(expectedDisplay, actualTranslation);
+
+            // compile the translated expression and ensure it matches the original logical expression
+            foreach (var expr in new string[] { mixedExpr, expectedDisplay, expectedLogical })
+            {
+                var result = engine.Compile(expr, new SqlCompileOptions());
+                Assert.AreEqual(expectedLogical, result.LogicalFormula);
+            }
+        }
+
         [DataTestMethod]
         [DataRow("Price * Quantity", "#$FieldDecimal$# * #$FieldDecimal$#", DisplayName = "Display Names")]
         [DataRow("new_price * new_quantity", "#$FieldDecimal$# * #$FieldDecimal$#", DisplayName = "Logical Names")]


### PR DESCRIPTION
Translating an expression with mixed display & logical names will hit Fx.Core assert. 
Existing Translate test is either exclusively one or the other. 

Note that translating back to invariant succeeds; it's just translating to Displaynames. 

This hits a contract assert in Fx.Core and fails. Contracts are only in debug builds, so this passes against latest nugets, but fails against a local fx build (which has asserts enabled). 


```
Contracts.Verify(Boolean f, String message)
DType.GetType(DName name)
Visitor.Visit(FirstNameNode node)
FirstNameNode.Accept(TexlVisitor visitor)
BinaryOpNode.Accept(TexlVisitor visitor)
Visitor.Run()
TexlBinding.Run(IBinderGlue glue, IExternalRuleScopeResolver scopeResolver, DataSourceToQueryOptionsMap queryOptionsMap, TexlNode node, INameResolver resolver, BindingConfig bindingConfig, Boolean updateDisplayNames, DType ruleScope, Boolean forceUpdateDisplayNames, IExternalRule rule, Features features)
ExpressionLocalizationHelper.ConvertExpression(String expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, PowerFxConfig fxConfig, Boolean toDisplay)
ExpressionLocalizationHelper.ConvertExpression(String expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, CultureInfo culture, Boolean toDisplay)
DataverseEngine.ConvertExpression(String expression, Boolean toDisplay) line 207
DataverseEngine.ConvertToDisplay(String expression) line 188
DataverseTests.MixedTranslate(String mixedExpr, String expectedDisplay, String expectedLogical) line 1497
```

The expression is `new_price * Quantity`, 
Failing on looking up 'Quantity' , because it's expecting logical names. 

It's ok to fail - but we shouldn't assert. 
