### PR TITLE
Improving AddTable contract documentation

### DIFF
--- a/src/PowerFx.Dataverse.Eval/DataverseConnection.cs
+++ b/src/PowerFx.Dataverse.Eval/DataverseConnection.cs
@@ -145,6 +145,7 @@ namespace Microsoft.PowerFx.Dataverse
         /// <param name="variableName"> name to use in the expressions. This is often the table's display name, 
         /// but the host can adjust to disambiguiate (Accounts, Accounts_1).</param>
         /// <param name="tableLogicalName">The table logical name in dataverse.</param>
+        /// <exception cref="InvalidOperationException">When tableLogicalName does not exist.</exception>
         /// <returns></returns>
         public TableValue AddTable(string variableName, string tableLogicalName)
         {

--- a/src/PowerFx.Dataverse.Tests/PluginExecutionTests/PluginExecutionTests.cs
+++ b/src/PowerFx.Dataverse.Tests/PluginExecutionTests/PluginExecutionTests.cs
@@ -1346,6 +1346,10 @@ namespace Microsoft.PowerFx.Dataverse.Tests
                 () => dv.AddTable("variableName", "local"),
                 "Table with logical name 'local' was already added as variableName.");
 
+            Assert.ThrowsException<InvalidOperationException>(
+                () => dv.AddTable("missing_table", "missingtable"),
+                "No table metadata for missingtable");
+
             RecordType r = dv.GetRecordType("local");
             Assert.AreEqual("variableName", r.TableSymbolName);
 


### PR DESCRIPTION
Issue #36.
If a table has not been added to DataverseConnection or it doesn't exist in Dataverse, throws an exception.
The `AddTable` method needs to inform what type of exception the host can expect.

Do we need some sort of a new `TryAddTable` method?