### PR TITLE
Fix 93, Add CdsEntityMetadataProvider.Clone

### DIFF
--- a/src/PowerFx.Dataverse.Tests/CdsEntityMetadataProviderTests.cs
+++ b/src/PowerFx.Dataverse.Tests/CdsEntityMetadataProviderTests.cs
@@ -1,0 +1,126 @@
+﻿//------------------------------------------------------------------------------
+// <copyright company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Intellisense;
+using Microsoft.PowerFx.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Microsoft.PowerFx.Dataverse.Tests
+{
+    [TestClass]
+    public class CdsEntityMetadataProviderTests
+    {
+
+        private static readonly EntityMetadataModel _trivial = new EntityMetadataModel
+        {
+            LogicalName = "local",
+            PrimaryIdAttribute = "localid",
+            Attributes = new AttributeMetadataModel[]
+            {
+                    new AttributeMetadataModel
+                     {
+                         LogicalName= "new_field",
+                         DisplayName = "field",
+                         AttributeType = AttributeTypeCode.Decimal
+                     },
+            }
+        };
+
+        class SwitchMetadataProvider : IXrmMetadataProvider
+        {
+            public Func<string, EntityMetadata> _func;
+            public IXrmMetadataProvider _inner;
+
+            public void Dispose()
+            {
+                _func = null;
+                _inner = null;
+            }
+
+            public bool TryGetEntityMetadata(string logicalOrDisplayName, out EntityMetadata entity)
+            {
+                if (_inner != null)
+                {
+                    return _inner.TryGetEntityMetadata(logicalOrDisplayName, out entity);
+                }
+
+                if (_func != null)
+                {
+                    entity = _func(logicalOrDisplayName);
+                    return entity != null;
+                }
+
+                throw new InvalidOperationException($"failure");
+            }
+        }
+
+        // Create a cloned CdsEntityMetadataProvider against a new provider.
+        [TestMethod]
+        public void Clone()
+        {
+            var provider1 = new SwitchMetadataProvider()
+            {
+                _inner = new MockXrmMetadataProvider(_trivial)
+            };
+
+            var metadataCache = new CdsEntityMetadataProvider(provider1);
+
+            // Will cache
+            var ok = metadataCache.TryGetXrmEntityMetadata("local", out var entityMetadata1);
+
+            Assert.IsTrue(ok);
+            Assert.IsNotNull(entityMetadata1);
+
+            // Dispose 
+            provider1.Dispose();
+
+            Assert.ThrowsException<InvalidOperationException>(() => metadataCache.TryGetXrmEntityMetadata("second", out entityMetadata1));
+
+            // Clone 
+            var provider2 = new SwitchMetadataProvider();
+            var metadataCache2 = metadataCache.Clone(provider2);
+                        
+
+            // hit the cache again
+            ok = metadataCache2.TryGetXrmEntityMetadata("local", out entityMetadata1);
+
+            Assert.IsTrue(ok);
+            Assert.IsNotNull(entityMetadata1);
+        }
+
+        [TestMethod]
+        public void CloneSharesCache()
+        {
+            var provider1 = new SwitchMetadataProvider();
+            var metadataCache = new CdsEntityMetadataProvider(provider1);
+
+            // Clone 
+            var provider2 = new SwitchMetadataProvider()
+            {
+                _inner = new MockXrmMetadataProvider(_trivial)
+            };
+            var metadataCache2 = metadataCache.Clone(provider2);
+
+            // hit the cache again
+            var ok = metadataCache2.TryGetXrmEntityMetadata("local", out var entityMetadata1);
+
+            Assert.IsTrue(ok);
+            Assert.IsNotNull(entityMetadata1);
+
+            // Shows up in original because they share a cahce
+            ok = metadataCache.TryGetXrmEntityMetadata("local", out entityMetadata1);
+
+            Assert.IsTrue(ok);
+            Assert.IsNotNull(entityMetadata1);
+        }
+    }
+}

--- a/src/PowerFx.Dataverse/CdsEntityMetadataProvider.cs
+++ b/src/PowerFx.Dataverse/CdsEntityMetadataProvider.cs
@@ -74,6 +74,30 @@ namespace Microsoft.PowerFx.Dataverse
             _document = new DataverseDocument(this);
         }
 
+        private CdsEntityMetadataProvider(IXrmMetadataProvider provider, CdsEntityMetadataProvider original, Func<string, string> displayNameLookup = null)
+        {
+            this._innerProvider = provider;
+            this._document = new DataverseDocument(this);
+
+            // Share all caches
+            this._optionSets = original._optionSets;
+            this._xrmCache = original._xrmCache;
+            this._cdsCache = original._cdsCache;
+            this._displayNameLookup = displayNameLookup ?? original._displayNameLookup;            
+        }
+
+        /// <summary>
+        /// Create a metadata provider that shares the cache, but is accessed via a new provider. 
+        /// This is important when the IXrmMetadataProvider are based on short lived IOranizationService objects,
+        /// but we want to share the cached results longer. 
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        public CdsEntityMetadataProvider Clone(IXrmMetadataProvider provider, Func<string, string> displayNameLookup = null)
+        {
+            return new CdsEntityMetadataProvider(provider, this, displayNameLookup);
+        }
+
         // Called by operations that just want to get the metadata. 
         internal bool TryGetDataSource(string logicalName, out DataverseDataSourceInfo dataSource)
         {


### PR DESCRIPTION
Fix #93 . 
IOrganizationService, and hence IXrmMetadataProvider, can be short lived (potentially scoped to a single request). 
But CdsEntityMetadataProvider has a cache that can be long-lived. 

So allow creating a new CdsEntityMetadataProvider that reused the cache of an existing one, but swaps out the IXrmMetadataProvider for a new one. 