### PR TITLE
Update to latest Fx.

### DIFF
--- a/src/Build.props
+++ b/src/Build.props
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-	  <PowerFxVersion>0.2.3-preview.20230323-1008</PowerFxVersion>
+	  <PowerFxVersion>0.2.3-preview.20230329-1003</PowerFxVersion>
     <DataverseParserVersion>0.1.0-ci-20230313-70017436</DataverseParserVersion>
   </PropertyGroup>
 

--- a/src/PowerFx.Dataverse.Tests/SqlExpressionTestCases/Switch.txt
+++ b/src/PowerFx.Dataverse.Tests/SqlExpressionTestCases/Switch.txt
@@ -1,0 +1,14 @@
+#override: Switch.txt
+
+// https://github.com/microsoft/Power-Fx-Dataverse/issues/115
+
+>> Switch(Blank(),0,3,Blank(),5,2,7,11)
+#Skip
+
+
+>> Switch(Blank(),"zero","3",Blank(),"5","two","7","11")
+#Skip
+
+
+>> Switch(Blank(),0,"3",Blank(),"5",2,"7","11")
+#Skip

--- a/src/PowerFx.Dataverse/DataverseIntellisenseData.cs
+++ b/src/PowerFx.Dataverse/DataverseIntellisenseData.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerFx.Dataverse
         /// should therefore be excluded from being suggested
         /// Note that ErrorKind is supported by the infra, but not in maker scenarios, so should be excluded
         /// </summary>
-        private readonly static string[] _supportedEnums = new [] { EnumConstants.TimeUnitEnumString };
+        private readonly static string[] _supportedEnums = new [] { Microsoft.PowerFx.Core.Utils.LanguageConstants.TimeUnitEnumString };
 
         /// <summary>
         /// Not all functions supported by the name resolver should be suggested for makers


### PR DESCRIPTION
Update to 0.2.3-preview.20230329-1003

1. Absorb breaking change in https://github.com/microsoft/Power-Fx/pull/1254, renamed EnumConstants to LanguageConstants
2. disable some new tests added in switch.txt. Filed  https://github.com/microsoft/Power-Fx-Dataverse/issues/115