### PR TITLE
Upgrade to latest Fx, absorbing some major changes.

### DIFF
--- a/src/Build.props
+++ b/src/Build.props
@@ -2,10 +2,10 @@
 <Project>
 
   <PropertyGroup>
-	  <PowerFxVersion>0.2.3-preview.20230413-1007</PowerFxVersion>
+	  <PowerFxVersion>0.2.3-preview.20230414-1011</PowerFxVersion>
       
       <!-- https://msazure.visualstudio.com/OneAgile/_artifacts/feed/PowerApps-Studio-Official/NuGet/Microsoft.PowerFx.Dataverse.Parser       -->
-    <DataverseParserVersion>0.1.0-ci-20230403-71123572</DataverseParserVersion>
+    <DataverseParserVersion>0.1.0-ci-20230415-71765385</DataverseParserVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/PowerFx.Dataverse.Tests/DataverseTests.cs
+++ b/src/PowerFx.Dataverse.Tests/DataverseTests.cs
@@ -950,7 +950,6 @@ END
         [DataRow("Today()", false, null, "Error 0-7: Today is not supported in formula columns, use UTCToday instead.", DisplayName = "Today not supported")]
         [DataRow("IsToday(Today())", false, null, "Error 0-16: IsToday is not supported in formula columns, use IsUTCToday instead.", DisplayName = "IsToday not supported")]
         [DataRow("IsUTCToday(UTCToday())", true, typeof(BooleanType), DisplayName = "IsUTCToday of UTCToday")]
-        [DataRow("UTCToday() = UTCNow()", true, typeof(BooleanType), DisplayName = "= UTCToday UTCNow")]
         [DataRow("IsUTCToday(tziDateOnly)", true, typeof(BooleanType), DisplayName = "IsUTCToday of TZI Date Only")]
         [DataRow("IsUTCToday(dateOnly)", true, typeof(BooleanType), DisplayName = "IsUTCToday of Date Only")]
         [DataRow("IsUTCToday(userLocalDateTime)", true, typeof(BooleanType), DisplayName = "IsUTCToday of User Local Date Time")]
@@ -979,7 +978,11 @@ END
         [DataRow("DateDiff(userLocalDateOnly, userLocalDateTime)", true, typeof(SqlDecimalType), DisplayName = "DateDiff User Local Date Only vs User Local Date Time")]
         [DataRow("userLocalDateTime > userLocalDateOnly", true, typeof(BooleanType), DisplayName = "> User Local Date Time vs. User Local Date Only")]
         [DataRow("tziDateTime <> tziDateOnly", true, typeof(BooleanType), DisplayName = "<> TZI Date Time vs. TZI Date Only")]
-        [DataRow("UTCToday() = tziDateOnly", true, typeof(BooleanType), DisplayName = "= UTCToday vs. TZI Date Only")]
+
+        // Regressed with https://github.com/microsoft/Power-Fx/issues/1379 
+        // [DataRow("UTCToday() = tziDateOnly", true, typeof(BooleanType), DisplayName = "= UTCToday vs. TZI Date Only")]
+        // [DataRow("UTCToday() = UTCNow()", true, typeof(BooleanType), DisplayName = "= UTCToday UTCNow")]
+
         [DataRow("UTCToday() = dateOnly", true, typeof(BooleanType), DisplayName = "= UTCToday vs. Date Only")]
         // TODO: the span for operations is potentially incorrect in the IR: it is only the operator, and not the operands
         [DataRow("tziDateTime = userLocalDateOnly", false, null, "Error 12-13: This operation cannot be performed on values which are of different Date Time Behaviors.", DisplayName = "= TZI Date Time vs. User Local Date Only")]

--- a/src/PowerFx.Dataverse.Tests/PluginExecutionTests/PluginExecutionTests.cs
+++ b/src/PowerFx.Dataverse.Tests/PluginExecutionTests/PluginExecutionTests.cs
@@ -265,7 +265,7 @@ namespace Microsoft.PowerFx.Dataverse.Tests
         //  expected: 'Rating (Locals)'.Warm     // but this won't parse, needs metadata.
 
         [DataTestMethod]
-        [DataRow("First(t1).Price", "100")] // trivial 
+        [DataRow("First(t1).Price", "Float(100)")] // trivial 
         [DataRow("t1", "t1")] // table
         [DataRow("First(t1)", "LookUp(t1, localid=GUID(\"00000000-0000-0000-0000-000000000001\"))")] // record
         [DataRow("LookUp(t1, false)", "If(false,First(FirstN(t1,0)))")] // blank
@@ -631,10 +631,11 @@ namespace Microsoft.PowerFx.Dataverse.Tests
             Assert.AreEqual(expected, result.ToObject());
         }
 
+        // Hyperlink types are imported as String
         [DataTestMethod]
         [DataRow("First(t1).hyperlink", "Hyperlink column type not supported.")]
         [DataRow("With({x:First(t1)}, x.hyperlink)", "Hyperlink column type not supported.")]
-        public void NotSupportedColumnTypeErrorTest(string expr, string expected)
+        public void HyperlinkIsString(string expr, string expected)
         {
             // create table "local"
             var logicalName = "allattributes";
@@ -654,9 +655,11 @@ namespace Microsoft.PowerFx.Dataverse.Tests
 
             var run = check.GetEvaluator();
             var result = run.EvalAsync(CancellationToken.None, dv.SymbolValues).Result;
+            
+            Assert.IsInstanceOfType(result, typeof(StringValue));
+            Assert.AreEqual(FormulaType.String, result.Type);
 
-            Assert.IsInstanceOfType(result, typeof(ErrorValue));
-            Assert.AreEqual(expected, ((ErrorValue)result).Errors.First().Message);
+            Assert.AreEqual("teste_url", result.ToObject());            
         }
 
         // Ensure a custom function shows up in intellisense. 

--- a/src/PowerFx.Dataverse.Tests/PowerFxEvaluationTests.cs
+++ b/src/PowerFx.Dataverse.Tests/PowerFxEvaluationTests.cs
@@ -66,11 +66,12 @@ namespace Microsoft.PowerFx.Dataverse.Tests
             using (var sql = new SqlRunner(ConnectionString))
             {
                 var runner = new TestRunner(sql);
-                //runner.AddFile(@"c:\temp\test.txt");
+                runner.AddFile(DataverseEngine.NumberIsFloat, @"c:\temp\t.txt");
+                /*
                 foreach (var path in Directory.EnumerateFiles(GetSqlDefaultTestDir(), "Sql.txt"))
                 {
                     runner.AddFile(DataverseEngine.NumberIsFloat, path);
-                }
+                }*/
 
                 var result = runner.RunTests();
 

--- a/src/PowerFx.Dataverse.Tests/SqlExpressionTestCases/SqlDisabledFiles.txt
+++ b/src/PowerFx.Dataverse.Tests/SqlExpressionTestCases/SqlDisabledFiles.txt
@@ -8,6 +8,7 @@
 // Enable decimal: 
 // https://github.com/microsoft/Power-Fx-Dataverse/issues/117
 #DISABLE: DecimalBoot.txt
+#DISABLE: DecimalMathFuncs.txt
 #DISABLE: DecimalNonMathFuncs.txt
 #DISABLE: DecimalOps.txt
 #DISABLE: DecimalOverflow.txt

--- a/src/PowerFx.Dataverse/CdsEntityMetadataProvider.cs
+++ b/src/PowerFx.Dataverse/CdsEntityMetadataProvider.cs
@@ -59,6 +59,10 @@ namespace Microsoft.PowerFx.Dataverse
 
         public CdsEntityMetadataProvider(IXrmMetadataProvider provider, IReadOnlyDictionary<string, string> displayNameLookup = null)
         {
+            // Flip Metadata parser into a mode where Hyperlink parses as String, Money parses as Number. 
+            // https://msazure.visualstudio.com/OneAgile/_git/PowerApps-Client/pullrequest/7953377
+            Microsoft.AppMagic.Authoring.Importers.ServiceConfig.WadlExtensions.PFxV1Semantics = true;
+
             _innerProvider = provider;
             if (displayNameLookup != null)
             {

--- a/src/PowerFx.Dataverse/PowerFx2SqlEngine.cs
+++ b/src/PowerFx.Dataverse/PowerFx2SqlEngine.cs
@@ -123,6 +123,7 @@ namespace Microsoft.PowerFx.Dataverse
                 {
                     if (error.MessageKey == "ErrUnknownFunction" || 
                         error.MessageKey == "ErrUnimplementedFunction" ||
+                        error.MessageKey == "ErrNumberExpected" || // remove when fixed: https://github.com/microsoft/Power-Fx/issues/1375
                         (error.MessageKey == "ErrBadType_ExpectedType_ProvidedType" && error._messageArgs?.Length == 2 && error._messageArgs.Contains("Table")))
                     {
                         sqlResult._unsupportedWarnings.Add(error.Message);

--- a/src/PowerFx.Dataverse/SqlVisitor.cs
+++ b/src/PowerFx.Dataverse/SqlVisitor.cs
@@ -385,10 +385,13 @@ namespace Microsoft.PowerFx.Dataverse
                     arg = node.Child.Accept(this, context);
                     return context.SetIntermediateVariable(node, $"IIF({arg} IS NULL, N'', {arg})");
 
+                // Nop coercions
+                case UnaryOpKind.DateToDateTime:
+                    return node.Child.Accept(this, context);
+
                 case UnaryOpKind.DateTimeToNumber:
                 case UnaryOpKind.DateTimeToTime:
                 case UnaryOpKind.DateTimeToDate:
-                case UnaryOpKind.DateToDateTime:
                 case UnaryOpKind.DateToNumber:
                 case UnaryOpKind.DateToTime:
                 case UnaryOpKind.NumberToDate:


### PR DESCRIPTION
Update to latest Fx.  This had several major breaks to absorb. 

1. Accepts changes  - this causes new coercion nodes that weren't implemented. Impl as nops (since that's what was happening before)
2. Picks up new DV parser, https://msazure.visualstudio.com/OneAgile/_git/PowerApps-Client/pullrequest/7953377, which treats Hyperlink as String, Money as Number. This conveniently also gives us hyperlink support (so will fix #59) .
3. More decimal changes, including improved FormulaValue.ToExpression serializer.

**Disabling some tests due to Fx regression:**
https://github.com/microsoft/Power-Fx/issues/1379

Also loosen check based on this regression in error message: https://github.com/microsoft/Power-Fx/issues/1375