### PR TITLE
BigInt update fix

### DIFF
--- a/src/PowerFx.Dataverse.Eval/AttributeUtilityExtensions.cs
+++ b/src/PowerFx.Dataverse.Eval/AttributeUtilityExtensions.cs
@@ -60,14 +60,21 @@ namespace Microsoft.PowerFx.Dataverse
                     }
                     else
                     {
-                        return (Decimal)((NumberValue)fxValue).Value;
+                        return (decimal)((NumberValue)fxValue).Value;
                     }
 
                 case AttributeTypeCode.Double:
                     return ((NumberValue)fxValue).Value;
 
                 case AttributeTypeCode.Integer:
-                    return (int)((NumberValue)fxValue).Value;
+                    if (fxValue is DecimalValue dvi)
+                    {
+                        return (int)dvi.Value;
+                    }
+                    else
+                    {
+                        return (int)((NumberValue)fxValue).Value;
+                    }
 
                 case AttributeTypeCode.Memo:
                 case AttributeTypeCode.String:


### PR DESCRIPTION
BigInt fields can be read but not written.  

With this fix, the following works:
```
> Patch(Contacts, First(Contacts), {bigint:9223372036854775806, CurrencyNumber:12345678901.1235, DecimalNumber:12345678901.1234567891})
{cr9f3_bigint:9223372036854775806, cr9f3_currencynumber:12345678901.1235, cr9f3_decimalnumber:12345678901.1234567891}

> With(First(Contacts), Patch(Contacts,ThisRecord, {bigint:bigint+1, CurrencyNumber:CurrencyNumber+0.0001, DecimalNumber:DecimalNumber+.0000000001} ))
{cr9f3_bigint:9223372036854775807, cr9f3_currencynumber:12345678901.1236, cr9f3_decimalnumber:12345678901.1234567892}
```

We should have better tests for this case.  But I'm not sure how that should be done.  It isn't a metadata thing - that's correct - it's about how actual values flow through at runtime and are cast.  I opened https://github.com/microsoft/Power-Fx-Dataverse/issues/249 to track.

I also updated Integer handling to accept Decimal.  We may want to change the metadata parser to map integer to decimal, so that math remains on decimal as long as possible.

FYI, to create a BigInt column:
```
Import-Module Microsoft.Xrm.Data.Powershell

$XRM = Get-CrmConnection -InteractiveMode

$a = New-Object Microsoft.Xrm.Sdk.Metadata.BigIntAttributeMetadata

$a.SchemaName = "cr9f3_BigInt";
$a.LogicalName = "cr9f3_bigint";
$a.DisplayName = new-object Microsoft.Xrm.Sdk.Label( "bigint", 1033 )

$car = new-object Microsoft.Xrm.Sdk.Messages.CreateAttributeRequest
$car.Attribute = $a
$car.EntityName = "contact"

$XRM.Execute( $car )
```