### PR TITLE
CdsEntityMetadataProvider.Clone() should not hold onto DType

### DIFF
--- a/src/PowerFx.Dataverse.Tests/CdsEntityMetadataProviderTests.cs
+++ b/src/PowerFx.Dataverse.Tests/CdsEntityMetadataProviderTests.cs
@@ -135,16 +135,16 @@ namespace Microsoft.PowerFx.Dataverse.Tests
 
             var ok = CDSMetadata.TryGetDataSource("local", out var dvSource);
             Assert.IsTrue(ok);
-            var DType = dvSource.Schema;
+            var schema = dvSource.Schema;
 
-            var p = new SwitchMetadataProvider();
-            var clone = CDSMetadata.Clone(p);
+            var anotherProvider = new SwitchMetadataProvider();
+            var clone = CDSMetadata.Clone(anotherProvider);
 
             var cloneOk = clone.TryGetDataSource("local", out var clonedDvSource);
             Assert.IsTrue(cloneOk);
-            var clonedDType = clonedDvSource.Schema;
+            var clonedSchema = clonedDvSource.Schema;
 
-            Assert.AreNotSame(DType, clonedDType);
+            Assert.AreNotSame(schema, clonedSchema);
         }
     }
 }

--- a/src/PowerFx.Dataverse/CdsEntityMetadataProvider.cs
+++ b/src/PowerFx.Dataverse/CdsEntityMetadataProvider.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerFx.Dataverse
             this._innerProvider = provider;
             this._document = new DataverseDocument(this);
 
-            // Share all caches except CDS cache, cause that will cache DType also which can lead to threading issues.
+            // Share all caches except CDS cache, since DataverseDataSourceInfo hold onto the metadata provider.
             this._optionSets = original._optionSets;
             this._xrmCache = original._xrmCache;
             this._displayNameLookup = displayNameLookup ?? original._displayNameLookup;            


### PR DESCRIPTION
Related Plugin Issue: https://dynamicscrm.visualstudio.com/OneCRM/_queries/edit/3466808/

Plugin clones CdsEntityMetadataProvider but it runs in a multithreaded environment.
Since the cache is shared across requests in Plugin, what ends up happening is another thread can hold onto DSInfo from some another thread if we cached the DS Info while cloning.