### PR TITLE
Draft: When using primary key, it's not a relationship.

### DIFF
--- a/src/PowerFx.Dataverse/Eval/Delegation/DelegationVisitor.cs
+++ b/src/PowerFx.Dataverse/Eval/Delegation/DelegationVisitor.cs
@@ -1276,8 +1276,21 @@ namespace Microsoft.PowerFx.Dataverse
             if (maybeFieldAccessNode is RecordFieldAccessNode fieldAccess)
             {
                 fieldName = fieldAccess.Field;
+                                
                 if (TryGetFieldName(context, fieldAccess.From, out var fromField))
                 {
+                    // If it's a relationship on a primary key, then it's not really a relationship.
+                    //   Filter(table, assigned_to.primaryKey = value) is  
+                    var recordType = ((AggregateType)fieldAccess.From.IRContext.ResultType);
+                    string primaryKeyName = "sys_id"; // $$$ How to get primary key name...
+
+                    if (fieldName == primaryKeyName)
+                    {
+                        fieldName = fromField;
+                        relations = null;
+                        return true; // handled 
+                    }
+
                     var relationMetadata = new RelationMetadata(fromField, false, null);
 
                     var serializedRelationMetadata = DelegationUtility.SerializeRelationMetadata(relationMetadata);


### PR DESCRIPTION
I hit a bug in this case, in my ServiceNow implementation. 

'sys_id' is a primary key on ServiceNow records. (unlike DV, where each table has a different primary key name, in SN, they're all the same name) .

'assigned_to' is a N:1 to another table.  It's a text/guid field. 

so this expression is checking who is assigned to current user:  

`Filter(incident, ThisRecord.assigned_to.sys_id = _currentUser)`

'thisrecord.assigned_To.sys_id' naively looks like an expands relationship; but it's not really.  since sys_id is primary key, it's still a flat field access. 

This draft PR verifies the theory. 