### PR TITLE
Add SQL and SQLEval functions to REPL

### DIFF
--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -110,6 +110,7 @@ namespace Microsoft.PowerFx
             config.AddFunction(new DVConnectFunction1Arg());
             config.AddFunction(new DVConnectFunction2Arg());
             config.AddFunction(new DVAddTableFunction());
+            config.AddFunction(new SQLConnect0Function());
             config.AddFunction(new SQLConnect1Function());
 
             var optionsSet = new OptionSet("Options", DisplayNameUtility.MakeUnique(options));
@@ -348,6 +349,27 @@ namespace Microsoft.PowerFx
                 _dv.AddTable(localNameSV.Value, logNameSV.Value);
 
                 return BooleanValue.New(true);
+            }
+        }
+
+        private class SQLConnect0Function : ReflectionFunction
+        {
+            public SQLConnect0Function()
+                : base("SQLConnect", FormulaType.Void)
+            {
+            }
+
+            public FormulaValue Execute()
+            {
+                var connectionString = Environment.GetEnvironmentVariable("FxTestSQLDatabase");
+                if (connectionString == null)
+                {
+                    var error = new ExpressionError() { Message = $"Error: Environment variable FxTestSQLDatabase not set" };
+                    return FormulaValue.NewError(error);
+                }
+
+                var sqlConnect1 = new SQLConnect1Function();
+                return sqlConnect1.Execute(StringValue.New(connectionString));
             }
         }
 
@@ -773,8 +795,10 @@ DVAddTable( DataverseTable )
 DVMetadata( DataverseTable )
     Displays metadata for the table.
 
-SQLConnect( SQLConnectionString )
+SQLConnect( [ SQLConnectionString ] )
     Connect to SQL Server for SQLEval.
+    If connection string not provided, attempts to use environment variable 
+    ""FxTestSQLDatabase"" which is used by the test suite.
 
 SQL( Formula )
     Display compiled T-SQL for Formula.

--- a/src/tools/Repl/Repl.csproj
+++ b/src/tools/Repl/Repl.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.PowerFx.Interpreter" Version="$(PowerFxVersion)" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.PowerFx.Json" Version="$(PowerFxVersion)" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.9" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" /> <!-- CVE-2022-26907 -->
     <PackageReference Include="Microsoft.PowerFx.Repl" Version="$(PowerFxVersion)" NoWarn="NU1605" />
@@ -27,6 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.PowerFx.Dataverse.Sql\Microsoft.PowerFx.Dataverse.Sql.csproj" />
     <ProjectReference Include="..\..\PowerFx.Dataverse.Eval\Microsoft.PowerFx.Dataverse.Eval.csproj" />
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>


### PR DESCRIPTION
This is a REPL only change. A reworking of https://github.com/microsoft/Power-Fx-Dataverse/pull/313.

Enables running expressions through the SQL compiler and local SQL instance rather than the C# interpreter, very handy for testing our SQL code generation. There is also a SQL function that will display the stored procedure that would be used. 

And some general maintenance on the REPL.

```
Microsoft Power Fx Console Formula REPL, Version 1.4.0.0
Enter Excel formulas.  Use "Help()" for details, "Option()" for options,
"DVConnect()" to connect to Dataverse, "SQLConnect()" for SQL execution.

>> // Place autoexec formulas in C:\Users\gregli\ReplDV.txt

>> SQLConnect()

>> SQLEval( 98765432198.7654321987 * 200 )
Blank()

>> 98765432198.7654321987 * 200
19753086439753.08643974

>> SQL( 98765432198.7654321987 * 200 )
CREATE FUNCTION fn_udf_c2789ae2b2614b5d9d4567a9d9d7e500(
) RETURNS decimal(23,10)
  WITH SCHEMABINDING
AS BEGIN
    DECLARE @v0 decimal(23,10)
    DECLARE @v1 decimal(23,10)
    DECLARE @v2 decimal(23,10)

    -- expression body
    SET @v0 = 98765432198.7654321987
    SET @v1 = 200
    SET @v2 = TRY_CAST((ISNULL(@v0,0) * ISNULL(@v1,0)) AS decimal(23,10))
    IF(@v2 IS NULL) BEGIN RETURN NULL END
    -- end expression body

    IF(@v2<-100000000000 OR @v2>100000000000) BEGIN RETURN NULL END
    RETURN ROUND(@v2, 10)
END

>>
```