### PR TITLE
Add manifest file to define the scope of the new loc process

### DIFF
--- a/localize/LocProject.json
+++ b/localize/LocProject.json
@@ -1,0 +1,16 @@
+{
+  "Projects": [
+    {
+      "LanguageSet": "PowerPlatform_NoBi-di_41_Languages",
+      "_LanguageSet.comment" : "PowerPlatform_NoBi-di_41_Languages resolves to bg-BG;ca-ES;cs-CZ;da-DK;de-DE;el-GR;es-ES;et-EE;eu-ES;fi-FI;fr-FR;gl-ES;hi-IN;hr-HR;hu-HU;id-ID;it-IT;ja-JP;kk-KZ;ko-KR;lt-LT;lv-LV;ms-MY;nb-NO;nl-NL;pl-PL;pt-BR;pt-PT;ro-RO;ru-RU;sk-SK;sl-SI;sr-Cyrl-RS;sr-Latn-RS;sv-SE;th-TH;tr-TR;uk-UA;vi-VN;zh-CN;zh-TW",
+      "LocItems": [
+        {
+          "SourceFile": "src\\strings\\DataverseResources.en-US.resx",
+          "CopyOption": "UsePlaceholders",
+          "OutputPath": "src\\strings\\DataverseResources.{Lang}.resx",
+          "_OutputPath.comment": "For instance, for ko-KR (Korean), OutputPath resolves to src\\strings\\DataverseResources.ko-KR.resx"
+        },
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add the manifest file to define the scope of the new loc process. Please refer to https://eng.ms/docs/cloud-ai-platform/azure-core/azure-experiences-and-ecosystems/cme-international-customer-exp/software-localization-onelocbuild/onelocbuild/onboarding/localizationproject for the schema of the manifest file.